### PR TITLE
fix: override tag correctly in push-latest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-08-11T21:28:45Z by kres 2fe6e2d-dirty.
+# Generated on 2020-08-12T13:22:50Z by kres 2849799-dirty.
 
 kind: pipeline
 type: kubernetes
@@ -170,14 +170,13 @@ steps:
   image: autonomy/build-container:latest
   commands:
   - docker login --username "$${DOCKER_USERNAME}" --password "$${DOCKER_PASSWORD}"
-  - make image-kres
+  - make image-kres TAG=latest
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password
     DOCKER_USERNAME:
       from_secret: docker_username
     PUSH: true
-    TAG: latest
   volumes:
   - name: outer-docker-socket
     path: /var/outer-run

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-08-11T21:25:18Z by kres 6e4c1a3-dirty.
+# Generated on 2020-08-12T13:21:54Z by kres 2849799-dirty.
 
 # common variables
 
@@ -22,7 +22,7 @@ BUILD := docker buildx build
 PLATFORM ?= linux/amd64
 PROGRESS ?= auto
 PUSH ?= false
-CI_ARGS ?= 
+CI_ARGS ?=
 COMMON_ARGS = --file=Dockerfile
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)

--- a/internal/output/drone/step.go
+++ b/internal/output/drone/step.go
@@ -6,6 +6,7 @@ package drone
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/drone/drone-yaml/yaml"
 )
@@ -16,12 +17,12 @@ type Step struct {
 }
 
 // MakeStep creates a step which calls make target.
-func MakeStep(target string) *Step {
+func MakeStep(target string, args ...string) *Step {
 	return &Step{
 		container: yaml.Container{
 			Name: target,
 			Commands: []string{
-				fmt.Sprintf("make %s", target),
+				strings.TrimSpace(fmt.Sprintf("make %s %s", target, strings.Join(args, " "))),
 			},
 			Environment: make(map[string]*yaml.Variable),
 		},

--- a/internal/output/makefile/makefile_test.go
+++ b/internal/output/makefile/makefile_test.go
@@ -35,7 +35,8 @@ func (suite *MakefileSuite) TestGenerateFile() {
 
 	output.VariableGroup(makefile.VariableGroupDocker).
 		Variable(makefile.SimpleVariable("BUILD", "docker buildx build")).
-		Variable(makefile.RecursiveVariable("ARGS", "do it").Push("once").Push("more"))
+		Variable(makefile.RecursiveVariable("ARGS", "do it").Push("once").Push("more")).
+		Variable(makefile.OverridableVariable("CI_ARGS", ""))
 
 	output.Target("all").
 		Depends("foo", "bar")
@@ -66,6 +67,7 @@ BUILD := docker buildx build
 ARGS = do it
 ARGS += once
 ARGS += more
+CI_ARGS ?=
 
 all: foo bar
 

--- a/internal/output/makefile/target.go
+++ b/internal/output/makefile/target.go
@@ -72,7 +72,7 @@ func (target *Target) Generate(w io.Writer) error {
 	}
 
 	for _, line := range target.script {
-		if _, err := fmt.Fprintf(w, "\t%s\n", line); err != nil {
+		if _, err := fmt.Fprintf(w, "\t%s\n", strings.TrimRight(line, " ")); err != nil {
 			return err
 		}
 	}

--- a/internal/output/makefile/variable.go
+++ b/internal/output/makefile/variable.go
@@ -71,7 +71,7 @@ func (variable *Variable) Generate(w io.Writer) error {
 		return nil
 	}
 
-	_, err := fmt.Fprintf(w, "%s %s %s\n", variable.name, variable.operator, variable.value)
+	_, err := fmt.Fprintln(w, strings.TrimSpace(fmt.Sprintf("%s %s %s", variable.name, variable.operator, variable.value)))
 
 	return err
 }

--- a/internal/project/common/image.go
+++ b/internal/project/common/image.go
@@ -55,10 +55,9 @@ func (image *Image) CompileDrone(output *drone.Output) error {
 	)
 
 	if image.PushLatest {
-		output.Step(drone.MakeStep(image.Name()).
+		output.Step(drone.MakeStep(image.Name(), "TAG=latest").
 			Name(fmt.Sprintf("push-%s-latest", image.ImageName)).
 			Environment("PUSH", "true").
-			Environment("TAG", "latest").
 			OnlyOnMaster().
 			ExceptPullRequest().
 			DockerLogin().


### PR DESCRIPTION
`TAG` is a simple variable to avoid multiple lookups of `$(shell ...)`,
so it has to be overridden on command line (vs. via environment
variables).

Clean up some trailing whitespace in Makefiles.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>