### PR TITLE
feat: implement code coverage support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,18 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2020-08-12T20:41:39Z by kres 3344820-dirty.
+
+codecov:
+require_ci_to_pass: false
+
+coverage:
+status:
+  project:
+    default:
+      target: 50%
+      threshold: 0.5%
+      base: auto
+      if_ci_failed: success
+  patch: off
+
+comment: false

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-08-12T13:22:50Z by kres 2849799-dirty.
+# Generated on 2020-08-12T20:49:47Z by kres e7b6f9f-dirty.
 
 kind: pipeline
 type: kubernetes
@@ -102,6 +102,26 @@ steps:
   depends_on:
   - base
 
+- name: coverage
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make coverage
+  environment:
+    CODECOV_TOKEN:
+      from_secret: CODECOV_TOKEN
+  volumes:
+  - name: outer-docker-socket
+    path: /var/outer-run
+  - name: docker-socket
+    path: /var/run
+  - name: ssh
+    path: /root/.ssh
+  - name: buildx
+    path: /root/.docker/buildx
+  depends_on:
+  - unit-tests
+
 - name: kres
   pull: always
   image: autonomy/build-container:latest
@@ -136,6 +156,7 @@ steps:
   depends_on:
   - kres
   - lint
+  - unit-tests
 
 - name: push-kres
   pull: always

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-08-12T13:57:16Z by kres 2d7355c-dirty.
+# Generated on 2020-08-12T20:46:00Z by kres 4718524-dirty.
 
 # common variables
 
@@ -108,6 +108,10 @@ unit-tests:  ## Performs unit tests
 .PHONY: unit-tests-race
 unit-tests-race:  ## Performs unit tests with race detection enabled.
 	@$(MAKE) target-$@
+
+.PHONY: coverage
+coverage:  ## Upload coverage data to codecov.io.
+	bash -c "bash <(curl -s https://codecov.io/bash) -f $(ARTIFACTS)/coverage.txt -X fix"
 
 .PHONY: $(ARTIFACTS)/kres
 $(ARTIFACTS)/kres:

--- a/cmd/kres/command/gen.go
+++ b/cmd/kres/command/gen.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/talos-systems/kres/internal/config"
 	"github.com/talos-systems/kres/internal/output"
+	"github.com/talos-systems/kres/internal/output/codecov"
 	"github.com/talos-systems/kres/internal/output/dockerfile"
 	"github.com/talos-systems/kres/internal/output/drone"
 	"github.com/talos-systems/kres/internal/output/gitignore"
@@ -62,6 +63,7 @@ func (c *Gen) Run(args []string) int {
 		license.NewOutput(),
 		gitignore.NewOutput(),
 		drone.NewOutput(),
+		codecov.NewOutput(),
 	}
 
 	var err error

--- a/internal/output/codecov/codecov.go
+++ b/internal/output/codecov/codecov.go
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package codecov implements output to .codecov.yml.
+package codecov
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/talos-systems/kres/internal/output"
+)
+
+const (
+	filename = ".codecov.yml"
+)
+
+// Output implements .codecov.yml generation.
+type Output struct {
+	output.FileAdapter
+
+	enabled bool
+	target  int
+}
+
+// NewOutput creates new codecov.yml output.
+func NewOutput() *Output {
+	output := &Output{
+		target: 50,
+	}
+
+	output.FileAdapter.FileWriter = output
+
+	return output
+}
+
+// Compile implements output.Writer interface.
+func (o *Output) Compile(node interface{}) error {
+	compiler, implements := node.(Compiler)
+
+	if !implements {
+		return nil
+	}
+
+	return compiler.CompileCodeCov(o)
+}
+
+// Enable should be called to enable config generation.
+func (o *Output) Enable() {
+	o.enabled = true
+}
+
+// Target sets target coverage threshold (percent).
+func (o *Output) Target(threshold int) {
+	o.target = threshold
+}
+
+// Filenames implements output.FileWriter interface.
+func (o *Output) Filenames() []string {
+	if !o.enabled {
+		return nil
+	}
+
+	return []string{filename}
+}
+
+// GenerateFile implements output.FileWriter interface.
+func (o *Output) GenerateFile(filename string, w io.Writer) error {
+	switch filename {
+	case filename:
+		return o.config(w)
+	default:
+		panic("unexpected filename: " + filename)
+	}
+}
+
+func (o *Output) config(w io.Writer) error {
+	if _, err := w.Write([]byte(output.Preamble("# "))); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, configTemplate, o.target); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Compiler is implemented by project blocks which support .codecov.yml generate.
+type Compiler interface {
+	CompileCodeCov(*Output) error
+}

--- a/internal/output/codecov/template.go
+++ b/internal/output/codecov/template.go
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package codecov
+
+const configTemplate = `codecov:
+require_ci_to_pass: false
+
+coverage:
+status:
+  project:
+    default:
+      target: %d%%
+      threshold: 0.5%%
+      base: auto
+      if_ci_failed: success
+  patch: off
+
+comment: false
+`

--- a/internal/output/drone/step.go
+++ b/internal/output/drone/step.go
@@ -43,6 +43,13 @@ func (step *Step) Environment(name, value string) *Step {
 	return step
 }
 
+// EnvironmentFromSecret appends an environment variable from secret to the step.
+func (step *Step) EnvironmentFromSecret(name, secretName string) *Step {
+	step.container.Environment[name] = &yaml.Variable{Secret: secretName}
+
+	return step
+}
+
 // DependsOn appends to a list of step dependencies.
 func (step *Step) DependsOn(depends ...string) *Step {
 	step.container.DependsOn = append(step.container.DependsOn, depends...)
@@ -52,14 +59,21 @@ func (step *Step) DependsOn(depends ...string) *Step {
 
 // ExceptPullRequest adds condition to skip step on PRs.
 func (step *Step) ExceptPullRequest() *Step {
-	step.container.When.Event.Exclude = []string{"pull_request"}
+	step.container.When.Event.Exclude = append(step.container.When.Event.Exclude, "pull_request")
+
+	return step
+}
+
+// OnlyOnPullRequest adds condition to run step only on PRs.
+func (step *Step) OnlyOnPullRequest() *Step {
+	step.container.When.Event.Include = append(step.container.When.Event.Include, "pull_request")
 
 	return step
 }
 
 // OnlyOnMaster adds condition to run step only on master branch.
 func (step *Step) OnlyOnMaster() *Step {
-	step.container.When.Branch.Include = []string{"master"}
+	step.container.When.Branch.Include = append(step.container.When.Branch.Include, "master")
 
 	return step
 }

--- a/internal/project/common/all.go
+++ b/internal/project/common/all.go
@@ -29,7 +29,7 @@ func NewAll(meta *meta.Options) *All {
 // CompileMakefile implements makefile.Compiler.
 func (all *All) CompileMakefile(output *makefile.Output) error {
 	output.Target("all").
-		Depends(all.InputNames()...)
+		Depends(dag.GatherMatchingInputNames(all, dag.Not(dag.Implements((*makefile.SkipAsMakefileDependency)(nil))))...)
 
 	return nil
 }

--- a/internal/project/service/codecov.go
+++ b/internal/project/service/codecov.go
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/talos-systems/kres/internal/dag"
+	"github.com/talos-systems/kres/internal/output/codecov"
+	"github.com/talos-systems/kres/internal/output/drone"
+	"github.com/talos-systems/kres/internal/output/makefile"
+	"github.com/talos-systems/kres/internal/project/meta"
+)
+
+// CodeCov provides build step which uploads coverage info to codecov.io.
+type CodeCov struct {
+	dag.BaseNode
+
+	meta *meta.Options
+
+	Enabled         bool   `yaml:"enabled"`
+	InputPath       string `yaml:"inputPath"`
+	TargetThreshold int    `yaml:"targetThreshold"`
+}
+
+// NewCodeCov initializes CodeCov.
+func NewCodeCov(meta *meta.Options) *CodeCov {
+	return &CodeCov{
+		BaseNode: dag.NewBaseNode("coverage"),
+
+		meta: meta,
+
+		Enabled:         true,
+		TargetThreshold: 50,
+	}
+}
+
+// CompileDrone implements drone.Compiler.
+func (coverage *CodeCov) CompileDrone(output *drone.Output) error {
+	if !coverage.Enabled {
+		return nil
+	}
+
+	output.Step(drone.MakeStep("coverage").
+		DependsOn(dag.GatherMatchingInputNames(coverage, dag.Implements((*drone.Compiler)(nil)))...).
+		EnvironmentFromSecret("CODECOV_TOKEN", "CODECOV_TOKEN"),
+	)
+
+	return nil
+}
+
+// CompileMakefile implements makefile.Compiler.
+func (coverage *CodeCov) CompileMakefile(output *makefile.Output) error {
+	if !coverage.Enabled {
+		return nil
+	}
+
+	output.Target("coverage").Description("Upload coverage data to codecov.io.").
+		Script(fmt.Sprintf(`bash -c "bash <(curl -s https://codecov.io/bash) -f $(ARTIFACTS)/%s -X fix"`, coverage.InputPath)).
+		Phony()
+
+	return nil
+}
+
+// CompileCodeCov implements codecov.Compiler.
+func (coverage *CodeCov) CompileCodeCov(output *codecov.Output) error {
+	if !coverage.Enabled {
+		return nil
+	}
+
+	output.Enable()
+	output.Target(coverage.TargetThreshold)
+
+	return nil
+}
+
+// SkipAsMakefileDependency implements makefile.SkipAsMakefileDependency.
+func (coverage *CodeCov) SkipAsMakefileDependency() {
+}

--- a/internal/project/service/codecov_test.go
+++ b/internal/project/service/codecov_test.go
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package service_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/kres/internal/output/drone"
+	"github.com/talos-systems/kres/internal/output/makefile"
+	"github.com/talos-systems/kres/internal/project/service"
+)
+
+func TestCodeCovInterfaces(t *testing.T) {
+	assert.Implements(t, (*makefile.Compiler)(nil), new(service.CodeCov))
+	assert.Implements(t, (*drone.Compiler)(nil), new(service.CodeCov))
+}

--- a/internal/project/service/service.go
+++ b/internal/project/service/service.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package service provides building blocks connecting to other services.
+package service

--- a/internal/project/wrap/drone.go
+++ b/internal/project/wrap/drone.go
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package wrap
+
+import (
+	"github.com/talos-systems/kres/internal/dag"
+	"github.com/talos-systems/kres/internal/output/drone"
+)
+
+// DroneWrapper wraps the node so that it has only drone.Compiler interface exposed.
+type DroneWrapper struct {
+	dag.Node
+}
+
+// Drone returns new DroneWrapper.
+func Drone(wrapped dag.Node) *DroneWrapper {
+	return &DroneWrapper{wrapped}
+}
+
+// CompileDrone implements drone.Compiler interface.
+func (drone *DroneWrapper) CompileDrone(*drone.Output) error {
+	return nil
+}

--- a/internal/project/wrap/drone_test.go
+++ b/internal/project/wrap/drone_test.go
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package wrap_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/kres/internal/output/drone"
+	"github.com/talos-systems/kres/internal/project/wrap"
+)
+
+func TestDroneInterfaces(t *testing.T) {
+	assert.Implements(t, (*drone.Compiler)(nil), wrap.Drone(nil))
+}

--- a/internal/project/wrap/wrap.go
+++ b/internal/project/wrap/wrap.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package wrap provides helper methods to wrap blocks to suppress (or add) some interfaces.
+package wrap


### PR DESCRIPTION
This includes generation of `.codecov.yml`, targets in Makefile and
Drone build, etc.

Fixes #2

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>