### PR TITLE
feat: allow base image to be customized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-08-11T14:39:54Z by kres ced23da-dirty.
+# Generated on 2020-08-12T20:55:10Z by kres 14148f4.
 
 ARG TOOLCHAIN
 
@@ -71,7 +71,8 @@ COPY --from=kres-build /kres /kres
 FROM scratch AS unit-tests
 COPY --from=unit-tests-run /src/coverage.txt /coverage.txt
 
-FROM kres AS image-kres
+FROM scratch AS image-kres
+COPY --from=kres / /
 COPY --from=image-fhs / /
 COPY --from=image-ca-certificates / /
 ENTRYPOINT ["/kres","gen"]


### PR DESCRIPTION
This allows container image to be built from e.g. `alpine:3.11` with
some custom `apk add` commands.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>