### PR TITLE
feat: provide support for non-standard Go package layout

### DIFF
--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -151,16 +151,8 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 		Step(step.Run("go", "mod", "download")).
 		Step(step.Run("go", "mod", "verify"))
 
-	goSourceDirectories := map[string]struct{}{
-		"cmd":      {},
-		"pkg":      {},
-		"internal": {},
-	}
-
-	for _, directory := range toolchain.meta.Directories {
-		if _, shouldCopy := goSourceDirectories[directory]; shouldCopy {
-			base.Step(step.Copy("./"+directory, "./"+directory))
-		}
+	for _, directory := range toolchain.meta.GoDirectories {
+		base.Step(step.Copy("./"+directory, "./"+directory))
 	}
 
 	base.Step(step.Script(`go list -mod=readonly all >/dev/null`))

--- a/internal/project/meta/meta.go
+++ b/internal/project/meta/meta.go
@@ -21,6 +21,9 @@ type Options struct {
 	// Directories which contain source code.
 	Directories []string
 
+	// GoDirectories are non-standard directories containing Go source code.
+	GoDirectories []string
+
 	// Source files on top level.
 	SourceFiles []string
 


### PR DESCRIPTION
For libraries it doesn't make sense to have a layout with
`pkg/` and `internal/`, so we need to support that.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>