### PR TITLE
feat: allow base image to be customized

### DIFF
--- a/internal/project/auto/golang.go
+++ b/internal/project/auto/golang.go
@@ -157,7 +157,7 @@ func (builder *builder) BuildGolang() error {
 		build.AddInput(toolchain)
 
 		image := common.NewImage(builder.meta, cmd)
-		image.AddInput(build, common.NewFHS(builder.meta), common.NewCACerts(builder.meta), builder.lintTarget, wrap.Drone(unitTests))
+		image.AddInput(build, builder.lintTarget, wrap.Drone(unitTests))
 
 		builder.targets = append(builder.targets, build, image)
 	}


### PR DESCRIPTION
This allows to drop standard fhs/ca-certificates in the final image.

In the future we might allow additional image types to be included.

(This is required for ci-bot which is based on Alpine).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>