### PR TITLE
feat: add cache volume for GOMODCACHE location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-08-19T15:36:34Z by kres 29f29d8-dirty.
+# Generated on 2020-08-20T18:05:09Z by kres 73f402f-dirty.
 
 ARG TOOLCHAIN
 
@@ -27,6 +27,7 @@ RUN apk --update --no-cache add bash curl build-base
 FROM toolchain AS tools
 ENV GO111MODULE on
 ENV CGO_ENABLED 0
+ENV GOPATH /go
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.30.0
 ARG GOFUMPT_VERSION
 RUN cd $(mktemp -d) \
@@ -39,8 +40,8 @@ FROM tools AS base
 WORKDIR /src
 COPY ./go.mod .
 COPY ./go.sum .
-RUN go mod download
-RUN go mod verify
+RUN --mount=type=cache,target=/go/pkg go mod download
+RUN --mount=type=cache,target=/go/pkg go mod verify
 COPY ./internal ./internal
 COPY ./cmd ./cmd
 RUN go list -mod=readonly all >/dev/null
@@ -51,7 +52,7 @@ WORKDIR /src/cmd/kres
 ARG VERSION_PKG="github.com/talos-systems/kres/internal/version"
 ARG SHA
 ARG TAG
-RUN --mount=type=cache,target=/root/.cache/go-build go build -ldflags "-s -w -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go build -ldflags "-s -w -X ${VERSION_PKG}.Name=kres -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kres
 
 # runs gofumpt
 FROM base AS lint-gofumpt
@@ -62,17 +63,17 @@ RUN FILES="$(gofumports -l -local github.com/talos-systems/kres .)" && test -z "
 FROM base AS lint-golangci-lint
 COPY .golangci.yml .
 ENV GOGC 50
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint golangci-lint run --config .golangci.yml
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint --mount=type=cache,target=/go/pkg golangci-lint run --config .golangci.yml
 
 # runs unit-tests with race detector
 FROM base AS unit-tests-race
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/tmp CGO_ENABLED=1 go test -v -race -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg --mount=type=cache,target=/tmp CGO_ENABLED=1 go test -v -race -count 1 ${TESTPKGS}
 
 # runs unit-tests
 FROM base AS unit-tests-run
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg --mount=type=cache,target=/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -count 1 ${TESTPKGS}
 
 FROM scratch AS kres
 COPY --from=kres-build /kres /kres

--- a/internal/project/golang/build.go
+++ b/internal/project/golang/build.go
@@ -53,7 +53,8 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 	}
 
 	stage.Step(step.Script(fmt.Sprintf(`go build -ldflags "%s" -o /%s`, ldflags, build.Name())).
-		MountCache(filepath.Join(build.meta.CachePath, "go-build")))
+		MountCache(filepath.Join(build.meta.CachePath, "go-build")).
+		MountCache(filepath.Join(build.meta.GoPath, "pkg")))
 
 	output.Stage(build.Name()).
 		From("scratch").

--- a/internal/project/golang/golangcilint.go
+++ b/internal/project/golang/golangcilint.go
@@ -71,7 +71,8 @@ func (lint *GolangciLint) CompileDockerfile(output *dockerfile.Output) error {
 		Step(step.Env("GOGC", "50")).
 		Step(step.Run("golangci-lint", "run", "--config", ".golangci.yml").
 			MountCache(filepath.Join(lint.meta.CachePath, "go-build")).
-			MountCache(filepath.Join(lint.meta.CachePath, "golangci-lint")),
+			MountCache(filepath.Join(lint.meta.CachePath, "golangci-lint")).
+			MountCache(filepath.Join(lint.meta.GoPath, "pkg")),
 		)
 
 	return nil

--- a/internal/project/golang/unit_tests.go
+++ b/internal/project/golang/unit_tests.go
@@ -40,6 +40,7 @@ func (tests *UnitTests) CompileDockerfile(output *dockerfile.Output) error {
 		Step(step.Arg("TESTPKGS")).
 		Step(step.Script(`go test -v -covermode=atomic -coverprofile=coverage.txt -count 1 ${TESTPKGS}`).
 			MountCache(filepath.Join(tests.meta.CachePath, "go-build")).
+			MountCache(filepath.Join(tests.meta.GoPath, "pkg")).
 			MountCache("/tmp"))
 
 	output.Stage("unit-tests").
@@ -52,6 +53,7 @@ func (tests *UnitTests) CompileDockerfile(output *dockerfile.Output) error {
 		Step(step.Arg("TESTPKGS")).
 		Step(step.Script(`go test -v -race -count 1 ${TESTPKGS}`).
 			MountCache(filepath.Join(tests.meta.CachePath, "go-build")).
+			MountCache(filepath.Join(tests.meta.GoPath, "pkg")).
 			MountCache("/tmp").
 			Env("CGO_ENABLED", "1"))
 

--- a/internal/project/meta/meta.go
+++ b/internal/project/meta/meta.go
@@ -45,6 +45,9 @@ type Options struct {
 	// Path to /bin.
 	BinPath string
 
+	// Go's GOPATH.
+	GoPath string
+
 	// Path to ~/.cache.
 	CachePath string
 }


### PR DESCRIPTION
In Go 1.15 there's separate environment variable to control the cache
locaiton: https://github.com/golang/go/issues/34527, but as we're on Go
1.14 yet, we use compatible approach with `GOPATH/pkg` being cached
across all Go-related build steps.

This speeds up `go mod download` a lot when only some module
dependencies got changed.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>