### PR TITLE
feat: allow image build to be skipped

### DIFF
--- a/internal/project/auto/config.go
+++ b/internal/project/auto/config.go
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package auto
+
+// NamedConfig is a base type which provides config name.
+type NamedConfig struct {
+	name string
+}
+
+// Name implements named interface.
+func (cfg *NamedConfig) Name() string {
+	return cfg.name
+}
+
+// CommandConfig sets up settings for command build.
+type CommandConfig struct {
+	NamedConfig
+
+	DisableImage bool `yaml:"disableImage"`
+}


### PR DESCRIPTION
Sometimes we don't need an image for the command, allow image to be
skipped.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>