### PR TITLE
fix: ensure we start alphas a alpha.0 version

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,14 +2,14 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-08-18T18:28:33Z by kres 215d1f3-dirty.
+# Generated on 2020-08-25T15:15:57Z by kres 94aea16-dirty.
 
 
 set -e
 
 function changelog {
   if [ "$#" -eq 1 ]; then
-    git-chglog --output CHANGELOG.md -c ./hack/git-chglog/config.yaml --tag-filter-pattern "^${1}" "${1}.0-alpha.1.."
+    git-chglog --output CHANGELOG.md -c ./hack/git-chglog/config.yaml --tag-filter-pattern "^${1}" "${1}.0-alpha.0.."
   elif [ "$#" -eq 0 ]; then
     git-chglog --output CHANGELOG.md -c ./hack/git-chglog/config.yaml
   else

--- a/internal/output/release/release.go
+++ b/internal/output/release/release.go
@@ -24,7 +24,7 @@ set -e
 
 function changelog {
   if [ "$#" -eq 1 ]; then
-    git-chglog --output CHANGELOG.md -c ./hack/git-chglog/config.yaml --tag-filter-pattern "^${1}" "${1}.0-alpha.1.."
+    git-chglog --output CHANGELOG.md -c ./hack/git-chglog/config.yaml --tag-filter-pattern "^${1}" "${1}.0-alpha.0.."
   elif [ "$#" -eq 0 ]; then
     git-chglog --output CHANGELOG.md -c ./hack/git-chglog/config.yaml
   else


### PR DESCRIPTION
This PR fixes a small bug in release.sh where we weren't starting our
alpha counting from *.0.