### PR TITLE
feat: support custom steps in Makefile/Drone

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -54,3 +54,18 @@ func walk(targets []Node, walkFn WalkFunc, visited map[Node]struct{}) error {
 
 	return nil
 }
+
+// FindByName walks the nodes to find the node with matching name.
+func FindByName(name string, targets ...Node) (result Node) {
+	visited := make(map[Node]struct{})
+
+	walk(targets, func(node Node) error { //nolint: errcheck
+		if node.Name() == name {
+			result = node
+		}
+
+		return nil
+	}, visited)
+
+	return
+}

--- a/internal/output/drone/step.go
+++ b/internal/output/drone/step.go
@@ -113,3 +113,10 @@ func (step *Step) DockerLogin() *Step {
 
 	return step
 }
+
+// Privileged marks step as privileged.
+func (step *Step) Privileged() *Step {
+	step.container.Privileged = true
+
+	return step
+}

--- a/internal/output/makefile/group.go
+++ b/internal/output/makefile/group.go
@@ -14,6 +14,7 @@ const (
 	VariableGroupCommon = "common variables"
 	VariableGroupDocker = "docker build settings"
 	VariableGroupHelp   = "help menu"
+	VariableGroupExtra  = "extra variables"
 )
 
 // VariableGroup is a way to group nicely variables in Makefile.

--- a/internal/project/auto/builder.go
+++ b/internal/project/auto/builder.go
@@ -55,6 +55,10 @@ func (builder *builder) build() error {
 			detect: builder.DetectMarkdown,
 			build:  builder.BuildMarkdown,
 		},
+		{ // custom should the the last in the list, so that step could be hooked up to the build
+			detect: builder.DetectCustom,
+			build:  builder.BuildCustom,
+		},
 	} {
 		ok, err := projectType.detect()
 		if err != nil {

--- a/internal/project/auto/config.go
+++ b/internal/project/auto/config.go
@@ -20,3 +20,15 @@ type CommandConfig struct {
 
 	DisableImage bool `yaml:"disableImage"`
 }
+
+// CustomSteps defines custom steps to be generated.
+type CustomSteps struct {
+	Steps []CustomStep `yaml:"steps"`
+}
+
+// CustomStep defines a custom step to be built.
+type CustomStep struct {
+	Name     string   `yaml:"name"`
+	Toplevel bool     `yaml:"toplevel"`
+	Inputs   []string `yaml:"inputs"`
+}

--- a/internal/project/auto/custom.go
+++ b/internal/project/auto/custom.go
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package auto
+
+import (
+	"fmt"
+
+	"github.com/talos-systems/kres/internal/dag"
+	"github.com/talos-systems/kres/internal/project/custom"
+)
+
+// DetectCustom checks if project has any custom steps.
+func (builder *builder) DetectCustom() (bool, error) {
+	var customSteps CustomSteps
+
+	if err := builder.meta.Config.Load(&customSteps); err != nil {
+		return false, err
+	}
+
+	return len(customSteps.Steps) > 0, nil
+}
+
+// BuildCustom builds custom project steps.
+func (builder *builder) BuildCustom() error {
+	var customSteps CustomSteps
+
+	if err := builder.meta.Config.Load(&customSteps); err != nil {
+		return err
+	}
+
+	createdSteps := []dag.Node{}
+
+	for _, spec := range customSteps.Steps {
+		step := custom.NewStep(builder.meta, spec.Name)
+
+		if spec.Toplevel {
+			builder.targets = append(builder.targets, step)
+		}
+
+		for _, inputName := range spec.Inputs {
+			input := dag.FindByName(inputName, append(builder.targets, createdSteps...)...)
+
+			if input == nil {
+				return fmt.Errorf("failed to find input node %q for custom step %q", inputName, spec.Name)
+			}
+
+			step.AddInput(input)
+		}
+
+		createdSteps = append(createdSteps, step)
+	}
+
+	return nil
+}

--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package custom provides blocks defined in the config manually.
+package custom
+
+import (
+	"github.com/talos-systems/kres/internal/dag"
+	"github.com/talos-systems/kres/internal/output/dockerfile"
+	"github.com/talos-systems/kres/internal/output/drone"
+	"github.com/talos-systems/kres/internal/output/makefile"
+	"github.com/talos-systems/kres/internal/project/meta"
+)
+
+// Step is defined in the config manually.
+type Step struct {
+	dag.BaseNode
+
+	meta *meta.Options
+
+	Makefile struct {
+		Enabled bool     `yaml:"enabled"`
+		Phony   bool     `yaml:"phony"`
+		Depends []string `yaml:"depends"`
+		Script  []string `yaml:"script"`
+
+		Variables []struct {
+			Name         string `yaml:"name"`
+			DefaultValue string `yaml:"defaultValue"`
+		} `yaml:"variables"`
+	} `yaml:"makefile"`
+
+	Drone struct {
+		Enabled    bool `yaml:"enabled"`
+		Privileged bool `yaml:"privileged"`
+	} `yaml:"drone"`
+}
+
+// NewStep initializes Step.
+func NewStep(meta *meta.Options, name string) *Step {
+	return &Step{
+		BaseNode: dag.NewBaseNode(name),
+		meta:     meta,
+	}
+}
+
+// CompileDockerfile implements dockerfile.Compiler.
+func (step *Step) CompileDockerfile(output *dockerfile.Output) error {
+	return nil
+}
+
+// CompileDrone implements drone.Compiler.
+func (step *Step) CompileDrone(output *drone.Output) error {
+	if !step.Drone.Enabled {
+		return nil
+	}
+
+	droneStep := drone.MakeStep(step.Name()).
+		DependsOn(dag.GatherMatchingInputNames(step, dag.Implements((*drone.Compiler)(nil)))...)
+
+	if step.Drone.Privileged {
+		droneStep.Privileged()
+	}
+
+	output.Step(droneStep)
+
+	return nil
+}
+
+// CompileMakefile implements makefile.Compiler.
+func (step *Step) CompileMakefile(output *makefile.Output) error {
+	if !step.Makefile.Enabled {
+		return nil
+	}
+
+	for _, variable := range step.Makefile.Variables {
+		output.VariableGroup(makefile.VariableGroupExtra).
+			Variable(makefile.OverridableVariable(variable.Name, variable.DefaultValue))
+	}
+
+	target := output.Target(step.Name()).
+		Depends(step.Makefile.Depends...).
+		Script(step.Makefile.Script...)
+
+	if step.Makefile.Phony {
+		target.Phony()
+	}
+
+	return nil
+}


### PR DESCRIPTION
Sometimes we need custom steps specific to the project, which can't be
derived from the project structure: e.g. running integration tests.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>