### PR TITLE
fix: make custom steps put correct Drone dependencies

### DIFF
--- a/internal/project/custom/custom.go
+++ b/internal/project/custom/custom.go
@@ -56,8 +56,20 @@ func (step *Step) CompileDrone(output *drone.Output) error {
 		return nil
 	}
 
+	droneMatches := func(node dag.Node) bool {
+		if !dag.Implements((*drone.Compiler)(nil))(node) {
+			return false
+		}
+
+		if nodeStep, ok := node.(*Step); ok {
+			return nodeStep.Drone.Enabled
+		}
+
+		return true
+	}
+
 	droneStep := drone.MakeStep(step.Name()).
-		DependsOn(dag.GatherMatchingInputNames(step, dag.Implements((*drone.Compiler)(nil)))...)
+		DependsOn(dag.GatherMatchingInputNames(step, droneMatches)...)
 
 	if step.Drone.Privileged {
 		droneStep.Privileged()


### PR DESCRIPTION
Steps in Kres usually discover whether they should record Drone
dependency on each other via the interfaces (whether parent interface
implements Drone interface), but custom steps always implement Drone
interface, but Drone step generation is controlled by the config, so
handle this case explicitly.

Discovered in Sfyra.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>