### PR TITLE
fix: remove status-lgtm from the list of required statuses

### DIFF
--- a/internal/project/common/repository.go
+++ b/internal/project/common/repository.go
@@ -44,7 +44,6 @@ func NewRepository(meta *meta.Options) *Repository {
 		MainBranch: "master",
 		EnforceContexts: []string{
 			"continuous-integration/drone/pr",
-			"status-lgtm",
 		},
 
 		EnableConform:     true,


### PR DESCRIPTION
We no longer use this with talos-bot.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>