### PR TITLE
feat: bump golangci-lint

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-10-23T19:27:38Z by kres e82c767-dirty.
+# Generated on 2021-02-02T18:00:41Z by kres da8cc39-dirty.
 
 kind: pipeline
 type: kubernetes

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-12-07T13:37:49Z by kres 31dc49d-dirty.
+# Generated on 2021-02-02T17:27:12Z by kres cbd82d1-dirty.
 
 
 # options for analysis running
@@ -128,6 +128,7 @@ linters:
     - wrapcheck
     - paralleltest
     - exhaustivestruct
+    - forbidigo
   disable-all: false
   fast: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-12-07T13:32:23Z by kres 31dc49d-dirty.
+# Generated on 2021-02-02T17:30:03Z by kres cbd82d1-dirty.
 
 ARG TOOLCHAIN
 
@@ -28,7 +28,7 @@ FROM toolchain AS tools
 ENV GO111MODULE on
 ENV CGO_ENABLED 0
 ENV GOPATH /go
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.33.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.36.0
 ARG GOFUMPT_VERSION
 RUN cd $(mktemp -d) \
 	&& go mod init tmp \

--- a/internal/output/golangci/config.go
+++ b/internal/output/golangci/config.go
@@ -130,6 +130,7 @@ linters:
     - wrapcheck
     - paralleltest
     - exhaustivestruct
+    - forbidigo
   disable-all: false
   fast: false
 

--- a/internal/project/auto/markdown.go
+++ b/internal/project/auto/markdown.go
@@ -9,8 +9,6 @@ import (
 )
 
 // DetectMarkdown checks if project at rootPath contains Markdown files.
-//
-//nolint: gocognit,gocyclo
 func (builder *builder) DetectMarkdown() (bool, error) {
 	for _, srcDir := range []string{"docs"} {
 		exists, err := directoryExists(builder.rootPath, srcDir)

--- a/internal/project/golang/golangcilint.go
+++ b/internal/project/golang/golangcilint.go
@@ -34,7 +34,7 @@ func NewGolangciLint(meta *meta.Options) *GolangciLint {
 
 		meta: meta,
 
-		Version: "v1.33.0",
+		Version: "v1.36.0",
 	}
 }
 


### PR DESCRIPTION
This forces build to run only on `ci` nodes.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>