### PR TITLE
feat: add an option to disable license checks and enforcement

### DIFF
--- a/internal/output/conform/conform.go
+++ b/internal/output/conform/conform.go
@@ -21,8 +21,9 @@ const (
 type Output struct {
 	output.FileAdapter
 
-	scopes []string
-	types  []string
+	scopes       []string
+	types        []string
+	licenseCheck bool
 
 	enabled bool
 }
@@ -60,6 +61,11 @@ func (o *Output) SetScopes(scopes []string) {
 // SetTypes sets the conventional commit types.
 func (o *Output) SetTypes(types []string) {
 	o.types = types
+}
+
+// SetLicenseCheck enables license check.
+func (o *Output) SetLicenseCheck(enable bool) {
+	o.licenseCheck = enable
 }
 
 // Filenames implements output.FileWriter interface.
@@ -102,11 +108,13 @@ func (o *Output) config(w io.Writer) error {
 	}
 
 	vars := struct {
-		Types  string
-		Scopes string
+		Types              string
+		Scopes             string
+		EnableLicenseCheck bool
 	}{
-		Types:  string(types),
-		Scopes: string(scopes),
+		Types:              string(types),
+		Scopes:             string(scopes),
+		EnableLicenseCheck: o.licenseCheck,
 	}
 
 	return tmpl.Execute(w, vars)

--- a/internal/output/conform/template.go
+++ b/internal/output/conform/template.go
@@ -22,6 +22,7 @@ const configTemplate = `policies:
     conventional:
       types: {{ .Types }}
       scopes: {{ .Scopes }}
+{{- if .EnableLicenseCheck }}
 - type: license
   spec:
     skipPaths:
@@ -34,4 +35,5 @@ const configTemplate = `policies:
       // This Source Code Form is subject to the terms of the Mozilla Public
       // License, v. 2.0. If a copy of the MPL was not distributed with this
       // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+{{ end -}}
 `

--- a/internal/output/license/license.go
+++ b/internal/output/license/license.go
@@ -18,6 +18,8 @@ const (
 // Output implements LICENSE generation.
 type Output struct {
 	output.FileAdapter
+
+	enabled bool
 }
 
 // NewOutput creates new Makefile output.
@@ -31,11 +33,26 @@ func NewOutput() *Output {
 
 // Compile implements output.Writer interface.
 func (o *Output) Compile(node interface{}) error {
-	return nil
+	compiler, implements := node.(Compiler)
+
+	if !implements {
+		return nil
+	}
+
+	return compiler.CompileLicense(o)
+}
+
+// Enable should be called to enable config generation.
+func (o *Output) Enable() {
+	o.enabled = true
 }
 
 // Filenames implements output.FileWriter interface.
 func (o *Output) Filenames() []string {
+	if !o.enabled {
+		return nil
+	}
+
 	return []string{filename}
 }
 
@@ -55,4 +72,9 @@ func (o *Output) license(w io.Writer) error {
 	}
 
 	return nil
+}
+
+// Compiler is implemented by project blocks which support LICENSE generation.
+type Compiler interface {
+	CompileLicense(*Output) error
 }


### PR DESCRIPTION
This allows Kres to skip LICENSE thing if configure to do so.

(used in talos-systems/release-tool)

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>