### PR TITLE
feat: add support for .proto files and compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-11T13:25:00Z by kres 93ce485-dirty.
+# Generated on 2021-03-17T21:13:39Z by kres 424ae88-dirty.
 
 ARG TOOLCHAIN
+
+# cleaned up specs and compiled versions
+FROM scratch AS generate
 
 FROM ghcr.io/talos-systems/ca-certificates:v0.3.0-12-g90722c3 AS image-ca-certificates
 
@@ -21,7 +24,7 @@ RUN markdownlint --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --ru
 
 # base toolchain image
 FROM ${TOOLCHAIN} AS toolchain
-RUN apk --update --no-cache add bash curl build-base
+RUN apk --update --no-cache add bash curl build-base protoc protobuf-dev
 
 # build tools
 FROM toolchain AS tools
@@ -48,6 +51,7 @@ RUN --mount=type=cache,target=/go/pkg go list -mod=readonly all >/dev/null
 
 # builds kres
 FROM base AS kres-build
+COPY --from=generate / /
 WORKDIR /src/cmd/kres
 ARG VERSION_PKG="github.com/talos-systems/kres/internal/version"
 ARG SHA

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-11T13:25:00Z by kres 93ce485-dirty.
+# Generated on 2021-03-16T20:02:57Z by kres 424ae88-dirty.
 
 # common variables
 
@@ -13,6 +13,8 @@ USERNAME ?= talos-systems
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 GO_VERSION ?= 1.14
+PROTOBUF_GO_VERSION ?= 1.25.0
+GRPC_GO_VERSION ?= 1.1.0
 TESTPKGS ?= ./...
 KRES_IMAGE ?= ghcr.io/talos-systems/kres:latest
 
@@ -33,6 +35,8 @@ COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
 COMMON_ARGS += --build-arg=TOOLCHAIN=$(TOOLCHAIN)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)
+COMMON_ARGS += --build-arg=PROTOBUF_GO_VERSION=$(PROTOBUF_GO_VERSION)
+COMMON_ARGS += --build-arg=GRPC_GO_VERSION=$(GRPC_GO_VERSION)
 COMMON_ARGS += --build-arg=TESTPKGS=$(TESTPKGS)
 TOOLCHAIN ?= docker.io/golang:1.16-alpine
 

--- a/internal/output/dockerfile/step/add.go
+++ b/internal/output/dockerfile/step/add.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package step
+
+import (
+	"fmt"
+	"io"
+)
+
+// AddStep implements Dockerfile COPY step.
+type AddStep struct {
+	src string
+	dst string
+}
+
+// Add creates new AddStep.
+func Add(src, dst string) *AddStep {
+	return &AddStep{
+		src: src,
+		dst: dst,
+	}
+}
+
+// Step implements Step interface.
+func (step *AddStep) Step() {}
+
+// Generate implements Step interface.
+func (step *AddStep) Generate(w io.Writer) error {
+	_, err := fmt.Fprintf(w, "ADD %s %s\n", step.src, step.dst)
+
+	return err
+}

--- a/internal/output/dockerfile/step/step_test.go
+++ b/internal/output/dockerfile/step/step_test.go
@@ -70,6 +70,10 @@ func TestGenerate(t *testing.T) {
 			step.Entrypoint("/bldr", "frontend"),
 			"ENTRYPOINT [\"/bldr\",\"frontend\"]\n",
 		},
+		{
+			step.Add("./src", "/dst"),
+			"ADD ./src /dst\n",
+		},
 	} {
 		var buf bytes.Buffer
 

--- a/internal/project/auto/golang.go
+++ b/internal/project/auto/golang.go
@@ -42,7 +42,7 @@ func (builder *builder) DetectGolang() (bool, error) {
 
 	builder.meta.CanonicalPath = modfile.ModulePath(contents)
 
-	for _, srcDir := range []string{"src", "internal", "pkg", "cmd"} {
+	for _, srcDir := range []string{"src", "internal", "pkg", "cmd", "api"} {
 		exists, err := directoryExists(builder.rootPath, srcDir)
 		if err != nil {
 			return true, err
@@ -138,6 +138,11 @@ func (builder *builder) BuildGolang() error {
 
 	// linters are input to the toolchain as they inject into toolchain build
 	toolchain.AddInput(golangciLint, gofumpt)
+
+	// add protobufs
+	protobuf := golang.NewProtobuf(builder.meta)
+
+	toolchain.AddInput(protobuf)
 
 	builder.lintInputs = append(builder.lintInputs, toolchain, golangciLint, gofumpt)
 

--- a/internal/project/golang/build.go
+++ b/internal/project/golang/build.go
@@ -38,6 +38,7 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 	stage := output.Stage(fmt.Sprintf("%s-build", build.Name())).
 		Description(fmt.Sprintf("builds %s", build.Name())).
 		From("base").
+		Step(step.Copy("/", "/").From("generate")).
 		Step(step.WorkDir(filepath.Join("/src", build.sourcePath)))
 
 	ldflags := "-s -w"

--- a/internal/project/golang/protobuf.go
+++ b/internal/project/golang/protobuf.go
@@ -1,0 +1,140 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package golang
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/talos-systems/kres/internal/dag"
+	"github.com/talos-systems/kres/internal/output/dockerfile"
+	"github.com/talos-systems/kres/internal/output/dockerfile/step"
+	"github.com/talos-systems/kres/internal/output/makefile"
+	"github.com/talos-systems/kres/internal/project/meta"
+)
+
+// Protobuf provides .proto compilation with grpc-go plugin.
+type Protobuf struct {
+	dag.BaseNode
+
+	meta *meta.Options
+
+	ProtobufGoVersion string `yaml:"protobufGoVersion"`
+	GrpcGoVersion     string `yaml:"grpcGoVersion"`
+
+	BaseSpecPath string `yaml:"baseSpecPath"`
+
+	Specs []ProtoSpec `yaml:"specs"`
+
+	ExperimentalFlags []string `yaml:"experimentalFlags"`
+}
+
+// ProtoSpec describes a set of protobuf specs to be compiled.
+type ProtoSpec struct {
+	Source       string `yaml:"source"`
+	SubDirectory string `yaml:"subdirectory"`
+}
+
+// NewProtobuf builds Protobuf node.
+func NewProtobuf(meta *meta.Options) *Protobuf {
+	meta.BuildArgs = append(meta.BuildArgs,
+		"PROTOBUF_GO_VERSION",
+		"GRPC_GO_VERSION",
+	)
+
+	return &Protobuf{
+		BaseNode: dag.NewBaseNode("protobuf"),
+
+		meta: meta,
+
+		ProtobufGoVersion: "v1.25.0",
+		GrpcGoVersion:     "v1.1.0",
+
+		BaseSpecPath: "/api",
+	}
+}
+
+// CompileMakefile implements makefile.Compiler.
+func (proto *Protobuf) CompileMakefile(output *makefile.Output) error {
+	output.VariableGroup(makefile.VariableGroupCommon).
+		Variable(makefile.OverridableVariable("PROTOBUF_GO_VERSION", strings.TrimLeft(proto.ProtobufGoVersion, "v"))).
+		Variable(makefile.OverridableVariable("GRPC_GO_VERSION", strings.TrimLeft(proto.GrpcGoVersion, "v")))
+
+	if len(proto.Specs) == 0 {
+		return nil
+	}
+
+	output.Target("generate").Description("Generate .proto definitions.").
+		Script("@$(MAKE) local-$@ DEST=./")
+
+	return nil
+}
+
+// ToolchainBuild implements common.ToolchainBuilder hook.
+func (proto *Protobuf) ToolchainBuild(stage *dockerfile.Stage) error {
+	if len(proto.Specs) == 0 {
+		return nil
+	}
+
+	stage.
+		Step(step.Arg("PROTOBUF_GO_VERSION")).
+		Step(step.Script("go install google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOBUF_GO_VERSION}")).
+		Step(step.Run("mv", filepath.Join(proto.meta.GoPath, "bin", "protoc-gen-go"), proto.meta.BinPath)).
+		Step(step.Arg("GRPC_GO_VERSION")).
+		Step(step.Script("go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${GRPC_GO_VERSION}")).
+		Step(step.Run("mv", filepath.Join(proto.meta.GoPath, "bin", "protoc-gen-go-grpc"), proto.meta.BinPath))
+
+	return nil
+}
+
+// CompileDockerfile implements dockerfile.Compiler.
+func (proto *Protobuf) CompileDockerfile(output *dockerfile.Output) error {
+	generate := output.Stage("generate").
+		Description("cleaned up specs and compiled versions").
+		From("scratch")
+
+	if len(proto.Specs) == 0 {
+		return nil
+	}
+
+	specs := output.Stage("proto-specs").
+		Description("collects proto specs").
+		From("scratch")
+
+	for _, spec := range proto.Specs {
+		specs.Step(
+			step.Add(spec.Source, filepath.Join(proto.BaseSpecPath, spec.SubDirectory)+"/"),
+		)
+	}
+
+	compile := output.Stage("proto-compile").
+		Description("runs protobuf compiler").
+		From("tools").
+		Step(step.Copy("/", "/").From("proto-specs"))
+
+	for _, spec := range proto.Specs {
+		compile.Step(
+			step.Run(
+				"protoc",
+				append(
+					append([]string{
+						fmt.Sprintf("-I%s", proto.BaseSpecPath),
+						fmt.Sprintf("--go_out=paths=source_relative:%s", proto.BaseSpecPath),
+						fmt.Sprintf("--go-grpc_out=paths=source_relative:%s", proto.BaseSpecPath),
+					},
+						proto.ExperimentalFlags...,
+					),
+					filepath.Join(proto.BaseSpecPath, spec.SubDirectory, filepath.Base(spec.Source)),
+				)...,
+			),
+		)
+	}
+
+	generate.Step(step.Copy(filepath.Clean(proto.BaseSpecPath)+"/", filepath.Clean(proto.BaseSpecPath)+"/").
+		From("proto-compile"))
+
+	return nil
+}

--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -125,7 +125,7 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 
 	if toolchain.Kind == ToolchainOfficial {
 		toolchainStage.
-			Step(step.Run("apk", "--update", "--no-cache", "add", "bash", "curl", "build-base"))
+			Step(step.Run("apk", "--update", "--no-cache", "add", "bash", "curl", "build-base", "protoc", "protobuf-dev"))
 	}
 
 	tools := output.Stage("tools").


### PR DESCRIPTION
`.proto` files are added explicitly via the `.kres.yaml`, copied from
exeternal "spec" repo, compiled to Go and available for the use.

Example:

```
kind: golang.Protobuf
spec:
  experimentalFlags:
    - --experimental_allow_proto3_optional
  specs:
    - source: https://raw.githubusercontent.com/smira/specification/resource-proto/proto/v1alpha1/resource/resource.proto
      subdirectory: v1alpha1/
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>