### PR TITLE
feat: add `coverpkg` to `go test` to produce full coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-17T21:13:39Z by kres 424ae88-dirty.
+# Generated on 2021-03-26T20:26:31Z by kres 9933cd1-dirty.
 
 ARG TOOLCHAIN
 
@@ -77,7 +77,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
 # runs unit-tests
 FROM base AS unit-tests-run
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg --mount=type=cache,target=/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg --mount=type=cache,target=/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 ${TESTPKGS}
 
 FROM scratch AS kres
 COPY --from=kres-build /kres /kres

--- a/internal/project/golang/unit_tests.go
+++ b/internal/project/golang/unit_tests.go
@@ -49,7 +49,7 @@ func (tests *UnitTests) CompileDockerfile(output *dockerfile.Output) error {
 		Description("runs unit-tests").
 		From("base").
 		Step(step.Arg("TESTPKGS")).
-		Step(wrapAsInsecure(step.Script(`go test -v -covermode=atomic -coverprofile=coverage.txt -count 1 ${TESTPKGS}`).
+		Step(wrapAsInsecure(step.Script(`go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 ${TESTPKGS}`).
 			MountCache(filepath.Join(tests.meta.CachePath, "go-build")).
 			MountCache(filepath.Join(tests.meta.GoPath, "pkg")).
 			MountCache("/tmp")))


### PR DESCRIPTION
This both tracks coverage for all packages, even those which don't have
tests, and also tracks coverage when test of one package touches other
packages.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>