### PR TITLE
feat: add all *.js files in the root of the frontend project

### DIFF
--- a/internal/project/auto/js.go
+++ b/internal/project/auto/js.go
@@ -43,6 +43,15 @@ func (builder *builder) DetectJS() (bool, error) {
 			}
 		}
 
+		results, err := listFilesWithSuffix(srcDir, ".js")
+		if err != nil {
+			return false, err
+		}
+
+		for _, item := range results {
+			builder.meta.JSDirectories = append(builder.meta.JSDirectories, filepath.Join(srcDir, item))
+		}
+
 		builder.meta.SourceFiles = append(builder.meta.SourceFiles,
 			filepath.Join(srcDir, "*.json"),
 			filepath.Join(srcDir, "*.js"),

--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -121,6 +121,12 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 		base.Step(step.Copy("./"+directory, "./"+strings.Trim(dest, "/")))
 	}
 
+	for _, file := range toolchain.meta.JSSourceFiles {
+		dest := filepath.Base(file)
+
+		base.Step(step.Copy(file, "./"+dest))
+	}
+
 	return nil
 }
 

--- a/internal/project/meta/meta.go
+++ b/internal/project/meta/meta.go
@@ -40,6 +40,9 @@ type Options struct { //nolint: govet
 	// Go source files on top level.
 	GoSourceFiles []string
 
+	// JS source files on top level.
+	JSSourceFiles []string
+
 	// Markdown source files on top level.
 	MarkdownSourceFiles []string
 


### PR DESCRIPTION
Different fronentd projects may have different set of config files
defined in the *.js files in the root of the project.

They should be automatically copied into build root directory.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>