### PR TITLE
feat: set the `USERNAME` to the GitHub org

### DIFF
--- a/internal/project/common/docker.go
+++ b/internal/project/common/docker.go
@@ -105,7 +105,7 @@ func (docker *Docker) CompileMakefile(output *makefile.Output) error {
 
 	output.VariableGroup(makefile.VariableGroupCommon).
 		Variable(makefile.OverridableVariable("REGISTRY", "ghcr.io")).
-		Variable(makefile.OverridableVariable("USERNAME", "talos-systems")).
+		Variable(makefile.OverridableVariable("USERNAME", docker.meta.GitHubOrganization)).
 		Variable(makefile.OverridableVariable("REGISTRY_AND_USERNAME", "$(REGISTRY)/$(USERNAME)"))
 
 	output.VariableGroup(makefile.VariableGroupDocker).


### PR DESCRIPTION
Makes things a bit less talos-systems centric.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>