### PR TITLE
fix: use vue3 rules as we use Vue 3 in our projects

### DIFF
--- a/internal/project/js/templates/eslint.yaml
+++ b/internal/project/js/templates/eslint.yaml
@@ -3,6 +3,6 @@ root: true
 env:
   node: true
 extends:
-  - "plugin:vue/essential"
+  - "plugin:vue/vue3-essential"
   - "eslint:recommended"
   - "@vue/typescript"


### PR DESCRIPTION
Otherwise it's using rules from Vue 2 and the compiler and linter fight
with each other.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>