### PR TITLE
feat: enable gRPC gateway files generation

### DIFF
--- a/internal/output/conform/template.go
+++ b/internal/output/conform/template.go
@@ -31,6 +31,7 @@ const configTemplate = `policies:
       - .go
     excludeSuffixes:
       - .pb.go
+      - .pb.gw.go
     header: |
       // This Source Code Form is subject to the terms of the Mozilla Public
       // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/internal/project/golang/gofumpt.go
+++ b/internal/project/golang/gofumpt.go
@@ -78,6 +78,7 @@ func (lint *Gofumpt) CompileDockerfile(output *dockerfile.Output) error {
 		Description("runs gofumpt").
 		From("base").
 		Step(step.Script(`find . -name '*.pb.go' | xargs -r rm`)).
+		Step(step.Script(`find . -name '*.pb.gw.go' | xargs -r rm`)).
 		Step(step.Script(
 			fmt.Sprintf(
 				`FILES="$(gofumports -l -local %s .)" && test -z "${FILES}" || (echo -e "Source code is not formatted with 'gofumports -w -local %s .':\n${FILES}"; exit 1)`,

--- a/internal/project/js/build.go
+++ b/internal/project/js/build.go
@@ -87,7 +87,7 @@ func (build *Build) CompileDrone(output *drone.Output) error {
 // CompileMakefile implements makefile.Compiler.
 func (build *Build) CompileMakefile(output *makefile.Output) error {
 	output.Target(fmt.Sprintf("$(ARTIFACTS)/%s-js", build.Name())).
-		Script(fmt.Sprintf("@$(MAKE) local-%s DEST=$(ARTIFACTS)", build.Name())).
+		Script(fmt.Sprintf("@$(MAKE) target-%s", build.Name())).
 		Phony()
 
 	output.Target(build.Name()).


### PR DESCRIPTION
gRPC gateway server wrappers are enabled by `genGateway` flag for each
particular spec.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>