### PR TITLE
feat: disable gRPC client generation for TypeScript

### DIFF
--- a/internal/project/js/protobuf.go
+++ b/internal/project/js/protobuf.go
@@ -138,6 +138,8 @@ func (proto *Protobuf) CompileDockerfile(output *dockerfile.Output) error {
 		args = append(args,
 			"--plugin=/root/.npm-global/.bin/protoc-gen-ts_proto.cmd",
 			fmt.Sprintf("--ts_proto_out=paths=source_relative:%s", dir),
+			"--ts_proto_opt=returnObservable=false",
+			"--ts_proto_opt=outputClientImpl=false",
 		)
 
 		args = append(args, proto.ExperimentalFlags...)


### PR DESCRIPTION
Generated clients compile only for Node.js, not for TypeScript running
on the web page.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>