### PR TITLE
fix: disable snakeToCamel flag for TS protobuf generation

### DIFF
--- a/internal/project/js/protobuf.go
+++ b/internal/project/js/protobuf.go
@@ -140,6 +140,7 @@ func (proto *Protobuf) CompileDockerfile(output *dockerfile.Output) error {
 			fmt.Sprintf("--ts_proto_out=paths=source_relative:%s", dir),
 			"--ts_proto_opt=returnObservable=false",
 			"--ts_proto_opt=outputClientImpl=false",
+			"--ts_proto_opt=snakeToCamel=false",
 		)
 
 		args = append(args, proto.ExperimentalFlags...)


### PR DESCRIPTION
Otherwise it converts `tail_events` to `tailEvents` and serializes it to
JSON like that.
Go protobuf JSON tags are defined in snake case.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>