### PR TITLE
feat: update golangci-lint and its configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,10 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-08-19T14:52:52Z by kres 29f29d8-dirty.
+# Generated on 2021-08-11T16:23:52Z by kres c77e3bf-dirty.
 
 **
-!internal
 !cmd
+!internal
 !go.mod
 !go.sum
 !.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-11T14:02:06Z by kres 93ce485-dirty.
-
+# Generated on 2021-08-11T16:25:38Z by kres c77e3bf-dirty.
 
 # options for analysis running
 run:
@@ -21,7 +20,6 @@ output:
   print-linter-name: true
   uniq-by-line: true
   path-prefix: ""
-
 
 # all available settings of specific linters
 linters-settings:
@@ -116,23 +114,23 @@ linters-settings:
 
 linters:
   enable-all: true
-  disable:
-    - gas
-    - typecheck
-    - gochecknoglobals
-    - gochecknoinits
-    - funlen
-    - godox
-    - gomnd
-    - goerr113
-    - nestif
-    - wrapcheck
-    - paralleltest
-    - exhaustivestruct
-    - forbidigo
   disable-all: false
   fast: false
-
+  disable:
+    - exhaustivestruct
+    - forbidigo
+    - funlen
+    - gas
+    - gochecknoglobals
+    - gochecknoinits
+    - godox
+    - goerr113
+    - gomnd
+    - nestif
+    - paralleltest
+    - tagliatelle
+    - typecheck
+    - wrapcheck
 
 issues:
   exclude: []
@@ -141,10 +139,8 @@ issues:
   exclude-case-sensitive: false
   max-issues-per-linter: 10
   max-same-issues: 3
-
   new: false
 
 severity:
   default-severity: error
-
   case-sensitive: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-05-21T00:52:36Z by kres c1b0c97-dirty.
+# Generated on 2021-08-11T16:23:52Z by kres c77e3bf-dirty.
 
 ARG TOOLCHAIN
 
@@ -31,11 +31,9 @@ FROM toolchain AS tools
 ENV GO111MODULE on
 ENV CGO_ENABLED 0
 ENV GOPATH /go
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.38.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.41.1
 ARG GOFUMPT_VERSION
-RUN cd $(mktemp -d) \
-	&& go mod init tmp \
-	&& go get mvdan.cc/gofumpt/gofumports@${GOFUMPT_VERSION} \
+RUN go install mvdan.cc/gofumpt/gofumports@${GOFUMPT_VERSION} \
 	&& mv /go/bin/gofumports /bin/gofumports
 
 # tools and sources
@@ -45,8 +43,8 @@ COPY ./go.mod .
 COPY ./go.sum .
 RUN --mount=type=cache,target=/go/pkg go mod download
 RUN --mount=type=cache,target=/go/pkg go mod verify
-COPY ./internal ./internal
 COPY ./cmd ./cmd
+COPY ./internal ./internal
 RUN --mount=type=cache,target=/go/pkg go list -mod=readonly all >/dev/null
 
 # builds kres-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-05-21T14:48:52Z by kres c09e0bc-dirty.
+# Generated on 2021-08-11T11:26:17Z by kres 907039b-dirty.
 
 # common variables
 
@@ -97,8 +97,8 @@ lint-gofumpt:  ## Runs gofumpt linter.
 fmt:  ## Formats the source code
 	@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) \
 		bash -c "export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; \
-		cd /tmp && go mod init tmp && go get mvdan.cc/gofumpt/gofumports@$(GOFUMPT_VERSION) && \
-		cd - && gofumports -w -local github.com/talos-systems/kres ."
+		go install mvdan.cc/gofumpt/gofumports@$(GOFUMPT_VERSION) && \
+		gofumports -w -local github.com/talos-systems/kres ."
 
 .PHONY: base
 base:  ## Prepare base toolchain

--- a/internal/output/codecov/codecov.go
+++ b/internal/output/codecov/codecov.go
@@ -6,7 +6,7 @@
 package codecov
 
 import (
-	_ "embed" //nolint:gci
+	_ "embed" //nolint:gci // allows go:embed usage
 	"fmt"
 	"io"
 

--- a/internal/output/golangci/golangci.go
+++ b/internal/output/golangci/golangci.go
@@ -6,6 +6,7 @@
 package golangci
 
 import (
+	_ "embed" //nolint:gci // allows go:embed usage
 	"fmt"
 	"io"
 
@@ -15,6 +16,9 @@ import (
 const (
 	filename = ".golangci.yml"
 )
+
+//go:embed golangci.yml
+var configTemplate string
 
 // Output implements .golangci.yml generation.
 type Output struct {
@@ -80,7 +84,7 @@ func (o *Output) config(w io.Writer) error {
 		return err
 	}
 
-	if _, err := fmt.Fprintf(w, config, o.canonicalPath); err != nil {
+	if _, err := fmt.Fprintf(w, configTemplate, o.canonicalPath); err != nil {
 		return err
 	}
 

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -1,10 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-package golangci
-
-const config = `
 # options for analysis running
 run:
   timeout: 10m
@@ -23,7 +16,6 @@ output:
   print-linter-name: true
   uniq-by-line: true
   path-prefix: ""
-
 
 # all available settings of specific linters
 linters-settings:
@@ -118,23 +110,23 @@ linters-settings:
 
 linters:
   enable-all: true
-  disable:
-    - gas
-    - typecheck
-    - gochecknoglobals
-    - gochecknoinits
-    - funlen
-    - godox
-    - gomnd
-    - goerr113
-    - nestif
-    - wrapcheck
-    - paralleltest
-    - exhaustivestruct
-    - forbidigo
   disable-all: false
   fast: false
-
+  disable:
+    - exhaustivestruct
+    - forbidigo
+    - funlen
+    - gas
+    - gochecknoglobals
+    - gochecknoinits
+    - godox
+    - goerr113
+    - gomnd
+    - nestif
+    - paralleltest
+    - tagliatelle
+    - typecheck
+    - wrapcheck
 
 issues:
   exclude: []
@@ -143,11 +135,8 @@ issues:
   exclude-case-sensitive: false
   max-issues-per-linter: 10
   max-same-issues: 3
-
   new: false
 
 severity:
   default-severity: error
-
   case-sensitive: false
-`

--- a/internal/project/golang/gofumpt.go
+++ b/internal/project/golang/gofumpt.go
@@ -52,8 +52,8 @@ func (lint *Gofumpt) CompileMakefile(output *makefile.Output) error {
 		Script(fmt.Sprintf(
 			`@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) \
 	bash -c "export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; \
-	cd /tmp && go mod init tmp && go get mvdan.cc/gofumpt/gofumports@$(GOFUMPT_VERSION) && \
-	cd - && gofumports -w -local %s ."`,
+	go install mvdan.cc/gofumpt/gofumports@$(GOFUMPT_VERSION) && \
+	gofumports -w -local %s ."`,
 			lint.meta.CanonicalPath,
 		))
 
@@ -64,9 +64,8 @@ func (lint *Gofumpt) CompileMakefile(output *makefile.Output) error {
 func (lint *Gofumpt) ToolchainBuild(stage *dockerfile.Stage) error {
 	stage.
 		Step(step.Arg("GOFUMPT_VERSION")).
-		Step(step.Script(fmt.Sprintf(`cd $(mktemp -d) \
-	&& go mod init tmp \
-	&& go get mvdan.cc/gofumpt/gofumports@${GOFUMPT_VERSION} \
+		Step(step.Script(fmt.Sprintf(
+			`go install mvdan.cc/gofumpt/gofumports@${GOFUMPT_VERSION} \
 	&& mv /go/bin/gofumports %s/gofumports`, lint.meta.BinPath)))
 
 	return nil

--- a/internal/project/golang/golangcilint.go
+++ b/internal/project/golang/golangcilint.go
@@ -34,7 +34,7 @@ func NewGolangciLint(meta *meta.Options) *GolangciLint {
 
 		meta: meta,
 
-		Version: "v1.38.0",
+		Version: "v1.41.1",
 	}
 }
 

--- a/internal/project/js/protobuf.go
+++ b/internal/project/js/protobuf.go
@@ -86,7 +86,7 @@ func (proto *Protobuf) ToolchainBuild(stage *dockerfile.Stage) error {
 		Step(step.Arg("PROTOBUF_TS_VERSION")).
 		Step(step.Script("npm install -g ts-proto@^${PROTOBUF_TS_VERSION}")).
 		Step(step.Arg("PROTOBUF_GRPC_GATEWAY_TS_VERSION")).
-		Step(step.Script("go get github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts@v${PROTOBUF_GRPC_GATEWAY_TS_VERSION}")).
+		Step(step.Script("go install github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts@v${PROTOBUF_GRPC_GATEWAY_TS_VERSION}")).
 		Step(step.Run("mv", filepath.Join(proto.meta.GoPath, "bin", "protoc-gen-grpc-gateway-ts"), proto.meta.BinPath))
 
 	return nil

--- a/internal/project/js/templates/templates.go
+++ b/internal/project/js/templates/templates.go
@@ -5,7 +5,7 @@
 // Package templates defines default templates for various JS components.
 package templates
 
-import _ "embed" // import embed to allow go:embed usage.
+import _ "embed" // allows go:embed usage
 
 // Babel babel.config.js.
 //go:embed babel.js


### PR DESCRIPTION
* disable new tagliatelle linter;
* sort disabled linters;
* move template to separate file;
* use `go install` for installing tools.

Signed-off-by: Alexey Palazhchenko <alexey.palazhchenko@talos-systems.com>