### PR TITLE
chore: update docker to 20.10 and disable some linters

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-05-21T14:48:52Z by kres c09e0bc-dirty.
+# Generated on 2021-08-24T17:25:25Z by kres e5f1e7e-dirty.
 
 kind: pipeline
 type: kubernetes
@@ -270,7 +270,7 @@ steps:
 
 services:
 - name: docker
-  image: docker:19.03-dind
+  image: docker:20.10-dind
   entrypoint:
   - dockerd
   commands:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-08-11T16:25:38Z by kres c77e3bf-dirty.
+# Generated on 2021-08-24T17:25:25Z by kres e5f1e7e-dirty.
 
 # options for analysis running
 run:
@@ -126,11 +126,18 @@ linters:
     - godox
     - goerr113
     - gomnd
+    - gomoddirectives
     - nestif
     - paralleltest
     - tagliatelle
+    - thelper
     - typecheck
     - wrapcheck
+    # abandoned linters for which golangci shows the warning that the repo is archived by the owner
+    - interfacer
+    - maligned
+    - golint
+    - scopelint
 
 issues:
   exclude: []

--- a/internal/output/golangci/golangci.yml
+++ b/internal/output/golangci/golangci.yml
@@ -122,11 +122,18 @@ linters:
     - godox
     - goerr113
     - gomnd
+    - gomoddirectives
     - nestif
     - paralleltest
     - tagliatelle
+    - thelper
     - typecheck
     - wrapcheck
+    # abandoned linters for which golangci shows the warning that the repo is archived by the owner
+    - interfacer
+    - maligned
+    - golint
+    - scopelint
 
 issues:
   exclude: []

--- a/internal/project/common/docker.go
+++ b/internal/project/common/docker.go
@@ -37,7 +37,7 @@ func NewDocker(meta *meta.Options) *Docker {
 
 		meta: meta,
 
-		DockerImage: "docker:19.03-dind",
+		DockerImage: "docker:20.10-dind",
 	}
 }
 


### PR DESCRIPTION
#### `thelper`

Usefullness of this linter is questionable and we already have this
linter disabled in Talos, so we're not following that pattern in most of
the projects.

#### `gomodirectives`

It only prohibits usage of `replace` in `go.mod`, but it looks like
using is inevitable right now in all our projects.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>