### PR TITLE
fix: use the same go version both in js protobuf as in go toolchain

### DIFF
--- a/cmd/kres/command/gen.go
+++ b/cmd/kres/command/gen.go
@@ -78,7 +78,9 @@ func (c *Gen) Run(args []string) int {
 
 	var err error
 
-	options := meta.Options{}
+	options := meta.Options{
+		GoContainerVersion: "1.16-alpine",
+	}
 
 	options.Config, err = config.NewProvider(".kres.yaml")
 	if err != nil {

--- a/internal/project/golang/toolchain.go
+++ b/internal/project/golang/toolchain.go
@@ -46,7 +46,7 @@ func NewToolchain(meta *meta.Options) *Toolchain {
 		meta: meta,
 
 		Kind:    ToolchainOfficial,
-		Version: "1.16-alpine",
+		Version: meta.GoContainerVersion,
 	}
 
 	meta.BuildArgs = append(meta.BuildArgs, "TOOLCHAIN")

--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -98,10 +98,12 @@ func (toolchain *Toolchain) CompileDockerfile(output *dockerfile.Output) error {
 	output.Stage("js-toolchain").
 		Description("base toolchain image").
 		From("${JS_TOOLCHAIN}").
-		Step(step.Run("apk", "--update", "--no-cache", "add", "bash", "curl", "protoc", "protobuf-dev", "go")).
+		Step(step.Copy("/usr/local/go", "/usr/local/go").From(fmt.Sprintf("golang:%s", toolchain.meta.GoContainerVersion))).
+		Step(step.Run("apk", "--update", "--no-cache", "add", "bash", "curl", "protoc", "protobuf-dev")).
 		Step(step.Copy("./go.mod", ".")).
 		Step(step.Copy("./go.sum", ".")).
-		Step(step.Env("GOPATH", toolchain.meta.GoPath))
+		Step(step.Env("GOPATH", toolchain.meta.GoPath)).
+		Step(step.Env("PATH", "${PATH}:/usr/local/go/bin"))
 
 	base := output.Stage("js").
 		Description("tools and sources").

--- a/internal/project/meta/meta.go
+++ b/internal/project/meta/meta.go
@@ -58,6 +58,9 @@ type Options struct { //nolint:govet
 	// Path to /bin.
 	BinPath string
 
+	// GoContainerVersion is the default go official container version.
+	GoContainerVersion string
+
 	// Go's GOPATH.
 	GoPath string
 


### PR DESCRIPTION
Previosly, go was installed into protobuf container using `apk add go`,
which installs go `1.15`, which does not support `go install
path@version` syntax.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>