### PR TITLE
fix: add `frontend/node_modules` to gitignore

### DIFF
--- a/internal/project/js/toolchain.go
+++ b/internal/project/js/toolchain.go
@@ -13,6 +13,7 @@ import (
 	"github.com/talos-systems/kres/internal/output/dockerfile"
 	"github.com/talos-systems/kres/internal/output/dockerfile/step"
 	"github.com/talos-systems/kres/internal/output/drone"
+	"github.com/talos-systems/kres/internal/output/gitignore"
 	"github.com/talos-systems/kres/internal/output/makefile"
 	"github.com/talos-systems/kres/internal/output/template"
 	"github.com/talos-systems/kres/internal/project/common"
@@ -46,6 +47,14 @@ func NewToolchain(meta *meta.Options, sourceDir string) *Toolchain {
 	meta.SourceFiles = append(meta.SourceFiles, ".babelrc", ".tsconfig")
 
 	return toolchain
+}
+
+// CompileGitignore implements gitignore.Compiler.
+func (toolchain *Toolchain) CompileGitignore(output *gitignore.Output) error {
+	output.
+		IgnorePath(filepath.Join(toolchain.sourceDir, "node_modules"))
+
+	return nil
 }
 
 // CompileTemplates implements template.Compiler.


### PR DESCRIPTION
As we now have dev server mode this `node_modules` folder might exist
locally, so it should be added to `.gitignore`.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>