### PR TITLE
fix: generate unique names for each command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-09-13T12:59:01Z by kres 7412de4-dirty.
+# Generated on 2021-11-07T12:42:33Z by kres latest.
 
 ARG TOOLCHAIN
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-09-22T20:01:02Z by kres 2a27963-dirty.
+# Generated on 2021-11-07T12:42:33Z by kres latest.
 
 # common variables
 

--- a/internal/project/golang/build.go
+++ b/internal/project/golang/build.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/talos-systems/kres/internal/dag"
 	"github.com/talos-systems/kres/internal/output/dockerfile"
@@ -91,12 +92,6 @@ func (build *Build) CompileDockerfile(output *dockerfile.Output) error {
 			Step(step.Copy("/"+name, "/"+name).From(fmt.Sprintf("%s-build", name)))
 	}
 
-	if len(build.Outputs) == 0 {
-		build.Outputs = map[string]CompileConfig{
-			fmt.Sprintf("%s-linux-amd64", build.Name()): nil,
-		}
-	}
-
 	for _, name := range build.getArtifacts() {
 		addBuildSteps(name, build.Outputs[name])
 	}
@@ -152,7 +147,7 @@ func (build *Build) getArtifacts() []string {
 		build.artifacts = []string{}
 
 		for name := range build.Outputs {
-			build.artifacts = append(build.artifacts, name)
+			build.artifacts = append(build.artifacts, strings.Join([]string{build.Name(), name}, "-"))
 		}
 
 		sort.Strings(build.artifacts)


### PR DESCRIPTION
Build names were same for all output executables if multiple build
outputs were specified.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>