### PR TITLE
fix: set build options for each go build target

### DIFF
--- a/internal/project/js/unit_tests.go
+++ b/internal/project/js/unit_tests.go
@@ -10,8 +10,6 @@ import (
 	"github.com/talos-systems/kres/internal/output/dockerfile/step"
 	"github.com/talos-systems/kres/internal/output/drone"
 	"github.com/talos-systems/kres/internal/output/makefile"
-	"github.com/talos-systems/kres/internal/output/template"
-	"github.com/talos-systems/kres/internal/project/js/templates"
 	"github.com/talos-systems/kres/internal/project/meta"
 )
 
@@ -24,8 +22,6 @@ type UnitTests struct {
 
 // NewUnitTests initializes UnitTests.
 func NewUnitTests(meta *meta.Options, name string) *UnitTests {
-	meta.SourceFiles = append(meta.SourceFiles, ".jestrc")
-
 	return &UnitTests{
 		BaseNode: dag.NewBaseNode(name),
 		meta:     meta,
@@ -53,14 +49,6 @@ func (tests *UnitTests) CompileMakefile(output *makefile.Output) error {
 		Description("Performs unit tests").
 		Script("@$(MAKE) target-$@").
 		Phony()
-
-	return nil
-}
-
-// CompileTemplates implements template.Compiler.
-func (tests *UnitTests) CompileTemplates(output *template.Output) error {
-	output.Define(".jestrc", templates.Jest).
-		PreamblePrefix("// ")
 
 	return nil
 }

--- a/internal/project/js/unit_tests_test.go
+++ b/internal/project/js/unit_tests_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/talos-systems/kres/internal/output/dockerfile"
 	"github.com/talos-systems/kres/internal/output/drone"
 	"github.com/talos-systems/kres/internal/output/makefile"
-	"github.com/talos-systems/kres/internal/output/template"
 	"github.com/talos-systems/kres/internal/project/js"
 )
 
@@ -20,5 +19,4 @@ func TestUnitTestsInterfaces(t *testing.T) {
 	assert.Implements(t, (*dockerfile.Compiler)(nil), new(js.UnitTests))
 	assert.Implements(t, (*makefile.Compiler)(nil), new(js.UnitTests))
 	assert.Implements(t, (*drone.Compiler)(nil), new(js.UnitTests))
-	assert.Implements(t, (*template.Compiler)(nil), new(js.UnitTests))
 }


### PR DESCRIPTION
Looks like it was broken after the last attempt to fix `multiple
executables` x `multiple build settings` support.

Also generate `tsconfig.json`, `babel.config.js` and `jest.config.js`
into the `frontend` folder now and do not overwrite them ever.

They may be project specific and it's easier to change them manually.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>